### PR TITLE
Optional branch name

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.2"
+version = "0.2.1"
 
 dependencies {
     // Align versions of all Kotlin components

--- a/plugin/src/main/kotlin/com/automattic/android/BuildEnvironment.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/BuildEnvironment.kt
@@ -1,32 +1,17 @@
 package com.automattic.android.publish
 
-const val BRANCH_NAME_ARGUMENT_NAME = "branch-name"
-const val SHA1_ARGUMENT_NAME = "sha1"
+sealed class BuildEnvironment {
+    data class FromTag(val tagName: String): BuildEnvironment()
+    data class FromPR(val pullRequestNumber: String, val sha1: String): BuildEnvironment()
+    data class FromBranch(val branchName: String, val sha1: String): BuildEnvironment()
 
-private val requiredArgumentsErrorMessage: String by lazy {
-    "--$BRANCH_NAME_ARGUMENT_NAME={branch-name} --$SHA1_ARGUMENT_NAME={sha1-commit-hash}" +
-        " command line arguments are required"
-}
-
-data class BuildEnvironment(
-    val tagName: String?,
-    val branchName: String,
-    val sha1: String,
-    val pullRequestUrl: String?
-) {
-    init {
-        require(branchName.isNotEmpty() && sha1.isNotEmpty()) {
-            requiredArgumentsErrorMessage
+    val versionName: String by lazy {
+        when (this) {
+            is FromTag -> tagName
+            is FromPR -> "$pullRequestNumber-$sha1"
+            is FromBranch -> "$branchName-$sha1"
         }
     }
-
-    fun calculateVersionName(): String =
-        if (!tagName.isNullOrEmpty()) {
-            tagName
-        } else if (!pullRequestUrl.isNullOrEmpty()) {
-            "${pullRequestUrl.substringAfterLast("/")}-$sha1"
-        } else {
-            "$branchName-$sha1"
-        } 
 }
+
 

--- a/plugin/src/main/kotlin/com/automattic/android/BuildEnvironmentArgs.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/BuildEnvironmentArgs.kt
@@ -1,0 +1,41 @@
+package com.automattic.android.publish
+
+import com.automattic.android.publish.BuildEnvironment
+
+private val requiredArgumentsErrorMessage: String by lazy {
+    "Either tagName or both branch name and sha1 command line arguments needs to be provided!\n" +
+    "Example usages:\n" +
+    "--tagName={tag-name}\n" +
+    "--pull-request-url={pull-request-url} --branch-name={branch-name} --sha1={sha1-commit-hash}\n" +
+    "--branch-name={branch-name} --sha1={sha1-commit-hash}"
+}
+
+data class BuildEnvironmentArgs(
+    val tagName: String?,
+    val branchName: String?,
+    val sha1: String?,
+    val pullRequestUrl: String?
+) {
+    fun process(): BuildEnvironment =
+        if (!tagName.isNullOrEmpty()) {
+            BuildEnvironment.FromTag(tagName)
+        } else {
+            val sha1 = requireNotNullOrEmpty(sha1)
+
+            if (!pullRequestUrl.isNullOrEmpty()) {
+                BuildEnvironment.FromPR(pullRequestNumber(pullRequestUrl), sha1)
+            } else {
+                val branchName = requireNotNullOrEmpty(branchName)
+                BuildEnvironment.FromBranch(branchName, sha1)
+            }
+        } 
+
+    private fun pullRequestNumber(pullRequestUrl: String): String =
+        pullRequestUrl.substringAfterLast("/")
+}
+
+private fun requireNotNullOrEmpty(value: String?, errorMessage: String = requiredArgumentsErrorMessage): String {
+    require(!value.isNullOrEmpty()) { errorMessage }
+    return value
+}
+

--- a/plugin/src/main/kotlin/com/automattic/android/CalculateVersionNameTask.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/CalculateVersionNameTask.kt
@@ -33,7 +33,8 @@ abstract class CalculateVersionNameTask : DefaultTask() {
 
     @TaskAction
     fun process() {
-        val versionName = BuildEnvironment(tagName, branchName, sha1, pullRequestUrl).calculateVersionName()
+        val versionName = BuildEnvironmentArgs(tagName, branchName, sha1, pullRequestUrl)
+            .process().versionName
         project.extraProperties.set(EXTRA_VERSION_NAME, versionName)
         println("${versionName}")
     }

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Task.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Task.kt
@@ -42,7 +42,8 @@ abstract class PublishToS3Task : DefaultTask() {
 
     @TaskAction
     fun process() {
-        val versionName = BuildEnvironment(tagName, branchName, sha1, pullRequestUrl).calculateVersionName()
+        val versionName = BuildEnvironmentArgs(tagName, branchName, sha1, pullRequestUrl)
+            .process().versionName
         project.extraProperties.set(EXTRA_VERSION_NAME, versionName)
         val isPublished = CheckS3Version(publishedGroupId, moduleName, versionName).check()
 

--- a/plugin/src/test/kotlin/com/automattic/android/BuildEnvironmentTest.kt
+++ b/plugin/src/test/kotlin/com/automattic/android/BuildEnvironmentTest.kt
@@ -1,6 +1,7 @@
 package com.automattic.android.publish
 
 import com.automattic.android.publish.BuildEnvironment
+import com.automattic.android.publish.BuildEnvironmentArgs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -18,35 +19,35 @@ class BuildEnvironmentTest {
     @Test
     fun `returns {tagName} for non-empty tag`() {
         val tagName = "tag-123"
-        val buildEnv = BuildEnvironment(
+        val buildEnv = BuildEnvironmentArgs(
             tagName = tagName,
             branchName = developBranchName,
             sha1 = sha1,
             pullRequestUrl = pullRequestUrl
-        )
-        assertEquals(tagName, buildEnv.calculateVersionName())
+        ).process()
+        assertEquals(tagName, buildEnv.versionName)
     }
 
     @Test
     fun `returns {pullRequestNumber-sha1} for empty tag on random branch`() {
-        val buildEnv = BuildEnvironment(
+        val buildEnv = BuildEnvironmentArgs(
             tagName = null,
-            branchName = randomBranchName,
+            branchName = null,
             sha1 = sha1,
             pullRequestUrl = pullRequestUrl
-        )
-        assertEquals("$pullRequestNumber-$sha1", buildEnv.calculateVersionName())
+        ).process()
+        assertEquals("$pullRequestNumber-$sha1", buildEnv.versionName)
     }
     @Test
     fun `returns {branchName-sha1} for empty tag and empty pull request url`() {
         listOf(developBranchName, trunkBranchName, randomBranchName).forEach { branchName ->
-            val buildEnv = BuildEnvironment(
+            val buildEnv = BuildEnvironmentArgs(
                 tagName = null,
                 branchName = branchName,
                 sha1 = sha1,
                 pullRequestUrl = null
-            )
-            assertEquals("$branchName-$sha1", buildEnv.calculateVersionName())
+            ).process()
+            assertEquals("$branchName-$sha1", buildEnv.versionName)
         }
     }
 }


### PR DESCRIPTION
This PR makes branch name optional so it won't fail for builds from tags. This was brought up [in this PR review](https://github.com/wordpress-mobile/circleci-orbs/pull/72#discussion_r622766999).

cc @mokagio 