### PR TITLE
Rename main plugin to library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.automattic.android.publish-to-s3")
+    id("com.automattic.android.publish-library-to-s3")
 }
 
 s3PublishPlugin {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -31,9 +31,9 @@ gradlePlugin {
         id = "com.automattic.android.publish-to-s3-base"
         implementationClass = "com.automattic.android.publish.PublishToS3BasePlugin"
     }
-    plugins.register("publish-to-s3") {
-        id = "com.automattic.android.publish-to-s3"
-        implementationClass = "com.automattic.android.publish.PublishToS3Plugin"
+    plugins.register("publish-library-to-s3") {
+        id = "com.automattic.android.publish-library-to-s3"
+        implementationClass = "com.automattic.android.publish.PublishLibraryToS3Plugin"
     }
 }
 

--- a/plugin/src/functionalTest/kotlin/com/automattic/android/CalculateVersionNameFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/automattic/android/CalculateVersionNameFunctionalTest.kt
@@ -16,21 +16,21 @@ private const val pullRequestUrl = "https://github.com/wordpress-mobile/WordPres
 class CalculateVersionNameFunctionalTest {
     @Test
     fun `fails for missing branch name`() {
-        val runner = publishToS3PluginFunctionalTestRunnerWithArguments("-q",
+        val runner = publishToS3BasePluginFunctionalTestRunnerWithArguments("-q",
             "calculateVersionName", "--sha1=$randomSha1")
         runner.buildAndFail()
     }
 
     @Test
     fun `fails for missing sha1`() {
-        val runner = publishToS3PluginFunctionalTestRunnerWithArguments("-q",
+        val runner = publishToS3BasePluginFunctionalTestRunnerWithArguments("-q",
             "calculateVersionName", "--branch-name=$randomBranchName")
         runner.buildAndFail()
     }
 
     @Test
     fun `returns {tagName} for non-empty tag`() {
-        val runner = publishToS3PluginFunctionalTestRunnerWithArguments("-q",
+        val runner = publishToS3BasePluginFunctionalTestRunnerWithArguments("-q",
             "calculateVersionName", "--branch-name=$developBranchName", "--sha1=$randomSha1",
             "--tag-name=$randomTagName")
         val result = runner.build()
@@ -39,7 +39,7 @@ class CalculateVersionNameFunctionalTest {
 
     @Test
     fun `returns {pullRequestNumber-sha1}`() {
-        val runner = publishToS3PluginFunctionalTestRunnerWithArguments("-q",
+        val runner = publishToS3BasePluginFunctionalTestRunnerWithArguments("-q",
             "calculateVersionName", "--branch-name=$developBranchName", "--sha1=$randomSha1",
             "--pull-request-url=$pullRequestUrl")
         val result = runner.build()
@@ -49,7 +49,7 @@ class CalculateVersionNameFunctionalTest {
     @Test
     fun `returns {branchName-sha1} for empty tag and empty pull request url`() {
         listOf(developBranchName, trunkBranchName, randomBranchName).forEach { branchName ->
-            val runner = publishToS3PluginFunctionalTestRunnerWithArguments("-q",
+            val runner = publishToS3BasePluginFunctionalTestRunnerWithArguments("-q",
                 "calculateVersionName", "--branch-name=$branchName", "--sha1=$randomSha1")
             val result = runner.build()
             val sanitizedBranchName = branchName.replace("/", "_")

--- a/plugin/src/functionalTest/kotlin/com/automattic/android/CheckS3VersionFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/automattic/android/CheckS3VersionFunctionalTest.kt
@@ -1,6 +1,5 @@
 package com.automattic.android.publish
 
-import com.automattic.android.publish.publishToS3PluginFunctionalTestRunnerWithArguments
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 import kotlin.test.Test
@@ -10,7 +9,7 @@ import kotlin.test.assertFalse
 class CheckS3VersionFunctionalTest {
     @Test
     fun `verify version exists`() {
-        val runner = publishToS3PluginFunctionalTestRunnerWithArguments("-q",
+        val runner = publishToS3BasePluginFunctionalTestRunnerWithArguments("-q",
             "isVersionPublishedToS3", "--version-name=1.40.0")
         val result = runner.build()
         assertTrue(result.output.trim().toBoolean())
@@ -18,7 +17,7 @@ class CheckS3VersionFunctionalTest {
 
     @Test
     fun `verify version does not exist`() {
-        val runner = publishToS3PluginFunctionalTestRunnerWithArguments("-q",
+        val runner = publishToS3BasePluginFunctionalTestRunnerWithArguments("-q",
             "isVersionPublishedToS3", "--version-name=thisversiondoesntexist")
         val result = runner.build()
         assertFalse(result.output.trim().toBoolean())

--- a/plugin/src/functionalTest/kotlin/com/automattic/android/PublishToS3PluginFunctionalTestRunner.kt
+++ b/plugin/src/functionalTest/kotlin/com/automattic/android/PublishToS3PluginFunctionalTestRunner.kt
@@ -3,16 +3,16 @@ package com.automattic.android.publish
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 
-fun publishToS3PluginFunctionalTestRunnerWithArguments(vararg arguments: String): GradleRunner {
+fun publishToS3BasePluginFunctionalTestRunnerWithArguments(vararg arguments: String): GradleRunner {
     val projectDir = File("build/functionalTest")
     projectDir.mkdirs()
     projectDir.resolve("settings.gradle").writeText("")
     projectDir.resolve("build.gradle.kts").writeText("""
             plugins {
-                id("com.automattic.android.publish-to-s3")
+                id("com.automattic.android.publish-to-s3-base")
             }
 
-            s3PublishPlugin {
+            s3PublishBasePlugin {
                 groupId = "org.wordpress"
                 artifactId = "utils"
             }

--- a/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Extension.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Extension.kt
@@ -1,6 +1,7 @@
 package com.automattic.android.publish
 
-interface PublishToS3PluginBaseExtension {
+interface PublishLibraryToS3Extension {
     var groupId: String
     var artifactId: String
+    var from: String?
 }

--- a/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Plugin.kt
@@ -2,8 +2,8 @@ package com.automattic.android.publish
 
 import com.automattic.android.publish.CalculateVersionNameTask
 import com.automattic.android.publish.PublishToS3BasePlugin
-import com.automattic.android.publish.PublishToS3PluginExtension
-import com.automattic.android.publish.PublishToS3PluginBaseExtension
+import com.automattic.android.publish.PublishToS3BaseExtension
+import com.automattic.android.publish.PublishLibraryToS3Extension
 import org.gradle.api.Project
 import org.gradle.api.Plugin
 import org.gradle.api.publish.PublishingExtension
@@ -12,20 +12,21 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 
 const val EXTRA_VERSION_NAME = "extra_version_name"
+private const val PUBLISH_TASK_NAME = "publishLibraryToS3"
 
-class PublishToS3Plugin : Plugin<Project> {
+class PublishLibraryToS3Plugin : Plugin<Project> {
     override fun apply(project: Project) {
-        val extension = project.extensions.create("s3PublishPlugin", PublishToS3PluginExtension::class.java)
+        val extension = project.extensions.create("s3PublishPlugin", PublishLibraryToS3Extension::class.java)
         project.plugins.apply(PublishToS3BasePlugin::class.java)
 
-        project.tasks.register("publishToS3", PublishToS3Task::class.java) {
+        project.tasks.register(PUBLISH_TASK_NAME, PublishLibraryToS3Task::class.java) {
             it.publishedGroupId = extension.groupId
             it.moduleName = extension.artifactId
             it.finalizedBy(project.tasks.named("publishS3PublicationToS3Repository"))
         }
 
         project.afterEvaluate { p ->
-            project.extensions.configure(PublishToS3PluginBaseExtension::class.java) {
+            project.extensions.configure(PublishToS3BaseExtension::class.java) {
                 it.groupId = extension.groupId
                 it.artifactId = extension.artifactId
             }
@@ -44,10 +45,10 @@ class PublishToS3Plugin : Plugin<Project> {
 
             p.tasks.withType(PublishToMavenRepository::class.java) { task ->
                 task.onlyIf {
-                    val state = p.tasks.getByName("publishToS3").state
+                    val state = p.tasks.getByName(PUBLISH_TASK_NAME).state
                     if (!state.executed) {
                         throw IllegalStateException("Publish tasks shouldn't be directly called." +
-                            " Please use 'publishToS3' task instead.")
+                            " Please use '$PUBLISH_TASK_NAME' task instead.")
                     }
                     state.failure == null
                 }

--- a/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Plugin.kt
@@ -1,9 +1,5 @@
 package com.automattic.android.publish
 
-import com.automattic.android.publish.CalculateVersionNameTask
-import com.automattic.android.publish.PublishToS3BasePlugin
-import com.automattic.android.publish.PublishToS3BaseExtension
-import com.automattic.android.publish.PublishLibraryToS3Extension
 import org.gradle.api.Project
 import org.gradle.api.Plugin
 import org.gradle.api.publish.PublishingExtension
@@ -19,7 +15,7 @@ class PublishLibraryToS3Plugin : Plugin<Project> {
         val extension = project.extensions.create("s3PublishPlugin", PublishLibraryToS3Extension::class.java)
         project.plugins.apply(PublishToS3BasePlugin::class.java)
 
-        project.tasks.register(PUBLISH_TASK_NAME, PublishLibraryToS3Task::class.java) {
+        project.tasks.register(PUBLISH_TASK_NAME, PublishToS3Task::class.java) {
             it.publishedGroupId = extension.groupId
             it.moduleName = extension.artifactId
             it.finalizedBy(project.tasks.named("publishS3PublicationToS3Repository"))

--- a/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Task.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Task.kt
@@ -11,7 +11,7 @@ import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 
-abstract class PublishToS3Task : DefaultTask() {
+abstract class PublishLibraryToS3Task : DefaultTask() {
     @Internal
     override fun getDescription(): String = "Calculates a version name and calls the publish task"
 

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3BaseExtension.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3BaseExtension.kt
@@ -1,7 +1,6 @@
 package com.automattic.android.publish
 
-interface PublishToS3PluginExtension {
+interface PublishToS3BaseExtension {
     var groupId: String
     var artifactId: String
-    var from: String?
 }

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3BasePlugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3BasePlugin.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.publish
 
-import com.automattic.android.publish.PublishToS3PluginBaseExtension
+import com.automattic.android.publish.PublishToS3BaseExtension
 import com.automattic.android.publish.CalculateVersionNameTask
 import com.automattic.android.publish.CheckS3VersionTask
 import java.net.URI
@@ -11,7 +11,7 @@ import org.gradle.api.credentials.AwsCredentials
 
 class PublishToS3BasePlugin  : Plugin<Project> {
     override fun apply(project: Project) {
-        val extension = project.extensions.create("s3PublishBasePlugin", PublishToS3PluginBaseExtension::class.java)
+        val extension = project.extensions.create("s3PublishBasePlugin", PublishToS3BaseExtension::class.java)
         project.plugins.apply("maven-publish")
 
         project.tasks.register("calculateVersionName", CalculateVersionNameTask::class.java)

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Task.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Task.kt
@@ -11,9 +11,10 @@ import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 
-abstract class PublishLibraryToS3Task : DefaultTask() {
+abstract class PublishToS3Task : DefaultTask() {
     @Internal
-    override fun getDescription(): String = "Calculates a version name and calls the publish task"
+    override fun getDescription(): String = "Calculates a version name and updates maven publication version" +
+        "- It should be finalized by the proper publish task"
 
     @get:Input
     abstract var publishedGroupId: String

--- a/plugin/src/test/kotlin/com/automattic/android/PublishLibraryToS3PluginTest.kt
+++ b/plugin/src/test/kotlin/com/automattic/android/PublishLibraryToS3PluginTest.kt
@@ -1,0 +1,27 @@
+package com.automattic.android.publish
+
+import org.gradle.testfixtures.ProjectBuilder
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertEquals
+
+class PublishLibraryToS3PluginTest {
+    @Test
+    fun `plugin registers task`() {
+        // Create a test project and apply the plugin
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("com.automattic.android.publish-library-to-s3")
+
+        // Verify the result
+        assertNotNull(project.tasks.findByName("calculateVersionName"))
+        assertNotNull(project.tasks.findByName("isVersionPublishedToS3"))
+        project.afterEvaluate {
+            /**
+             * "publishS3PublicationToS3Repository" task is only available after the project is evaluated
+             * which causes the test to crash. We get around this issue by testing this task only
+             * after project is evaluated which matches the actual behaviour of the plugin.
+             */
+            assertNotNull(project.tasks.findByName("publishLibraryToS3"))
+        }
+    }
+}

--- a/plugin/src/test/kotlin/com/automattic/android/PublishToS3BasePluginTest.kt
+++ b/plugin/src/test/kotlin/com/automattic/android/PublishToS3BasePluginTest.kt
@@ -4,12 +4,12 @@ import org.gradle.testfixtures.ProjectBuilder
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 
-class PublishToS3PluginTest {
+class PublishToS3BasePluginTest {
     @Test
     fun `plugin registers task`() {
         // Create a test project and apply the plugin
         val project = ProjectBuilder.builder().build()
-        project.plugins.apply("com.automattic.android.publish-to-s3")
+        project.plugins.apply("com.automattic.android.publish-to-s3-base")
 
         // Verify the result
         assertNotNull(project.tasks.findByName("calculateVersionName"))


### PR DESCRIPTION
_This PR is part of a larger set of changes and should be treated as a step towards the goal of having multiple plugins handling different functionalities. I am splitting these up to make it easier to review the changes._

This particular PR only renames the main plugin to `library` so it's clear it's designed to publish libraries. It also introduces `PublishLibraryToS3PluginTest` which just verifies the tasks in the library plugin.