### PR TITLE
Introduces ProjectExtensions for some cleanup

### DIFF
--- a/plugin/src/main/kotlin/com/automattic/android/CalculateVersionNameTask.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/CalculateVersionNameTask.kt
@@ -32,7 +32,7 @@ abstract class CalculateVersionNameTask : DefaultTask() {
     fun process() {
         val versionName = BuildEnvironmentArgs(tagName, branchName, sha1, pullRequestUrl)
             .process().versionName
-        project.extraProperties.set(EXTRA_VERSION_NAME, versionName)
+        project.setExtraVersionName(versionName)
         println("${versionName}")
     }
 }

--- a/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
@@ -1,0 +1,23 @@
+package com.automattic.android.publish
+
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+
+private const val EXTRA_VERSION_NAME = "extra_version_name"
+
+fun Project.setExtraVersionName(versionName: String) {
+    project.extraProperties.set(EXTRA_VERSION_NAME, versionName)
+}
+
+fun Project.getExtraVersionName() {
+    project.extraProperties.get(EXTRA_VERSION_NAME)
+}
+
+fun Project.setVersionForAllMavenPublications(versionName: String) {
+    project.getExtensions().getByType(PublishingExtension::class.java)
+        .publications.withType(MavenPublication::class.java).forEach {
+            it.version = versionName
+        }
+}
+

--- a/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishLibraryToS3Plugin.kt
@@ -7,7 +7,6 @@ import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 
-const val EXTRA_VERSION_NAME = "extra_version_name"
 private const val PUBLISH_TASK_NAME = "publishLibraryToS3"
 
 class PublishLibraryToS3Plugin : Plugin<Project> {
@@ -50,7 +49,7 @@ class PublishLibraryToS3Plugin : Plugin<Project> {
                 }
 
                 task.doLast {
-                    println("'${project.extraProperties.get(EXTRA_VERSION_NAME)}' is succesfully published.")
+                    println("'${project.getExtraVersionName()}' is succesfully published.")
                 }
             }
         }


### PR DESCRIPTION
_This PR is part of a larger set of changes and should be treated as a step towards the goal of having multiple plugins handling different functionalities. I am splitting these up to make it easier to review the changes._

This PR introduces `ProjectExtensions` which helps clean things up a bit.