### PR TITLE
Add publish plugin plugin

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.2.2"
+version = "0.3"
 
 dependencies {
     // Align versions of all Kotlin components

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -35,6 +35,10 @@ gradlePlugin {
         id = "com.automattic.android.publish-library-to-s3"
         implementationClass = "com.automattic.android.publish.PublishLibraryToS3Plugin"
     }
+    plugins.register("publish-plugin-to-s3") {
+        id = "com.automattic.android.publish-plugin-to-s3"
+        implementationClass = "com.automattic.android.publish.PublishPluginToS3Plugin"
+    }
 }
 
 // Add a source set for the functional test suite

--- a/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
@@ -53,3 +53,4 @@ fun Project.addFilterAndFinalizerToPublishToMavenRepositoryTasks(filterTask: Str
         }
     }
 }
+

--- a/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
@@ -4,6 +4,7 @@ import java.net.URI
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.credentials.AwsCredentials
 
 private const val EXTRA_VERSION_NAME = "extra_version_name"
@@ -32,6 +33,23 @@ fun Project.setupS3Repository() {
                 it.setAccessKey(System.getenv("AWS_ACCESS_KEY"))
                 it.setSecretKey(System.getenv("AWS_SECRET_KEY"))
             }
+        }
+    }
+}
+
+fun Project.addFilterAndFinalizerToPublishToMavenRepositoryTasks(filterTask: String) {
+    project.tasks.withType(PublishToMavenRepository::class.java) { task ->
+        task.onlyIf {
+            val state = project.tasks.getByName(filterTask).state
+            if (!state.executed) {
+                throw IllegalStateException("Publish tasks shouldn't be directly called." +
+                    " Please use '$filterTask' task instead.")
+            }
+            state.failure == null
+        }
+
+        task.doLast {
+            println("'${project.getExtraVersionName()}' is succesfully published.")
         }
     }
 }

--- a/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Extension.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Extension.kt
@@ -1,8 +1,7 @@
 package com.automattic.android.publish
 
-interface PublishLibraryToS3Extension {
+interface PublishPluginToS3Extension {
     var groupId: String
     var artifactId: String
-    var from: String?
 }
 

--- a/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Plugin.kt
@@ -7,7 +7,9 @@ private const val PUBLISH_PLUGIN_TASK_NAME = "publishPluginToS3"
 
 class PublishPluginToS3Plugin : Plugin<Project> {
     override fun apply(project: Project) {
-        val extension = project.extensions.create("s3PublishPlugin", PublishLibraryToS3Extension::class.java)
+        project.plugins.apply("maven-publish")
+
+        val extension = project.extensions.create("s3PublishPlugin", PublishPluginToS3Extension::class.java)
         project.setupS3Repository()
 
         project.tasks.register(PUBLISH_PLUGIN_TASK_NAME, PublishToS3Task::class.java) {

--- a/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Plugin.kt
@@ -1,0 +1,22 @@
+package com.automattic.android.publish
+
+import org.gradle.api.Project
+import org.gradle.api.Plugin
+
+private const val PUBLISH_PLUGIN_TASK_NAME = "publishPluginToS3"
+
+class PublishPluginToS3Plugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension = project.extensions.create("s3PublishPlugin", PublishLibraryToS3Extension::class.java)
+        project.setupS3Repository()
+
+        project.tasks.register(PUBLISH_PLUGIN_TASK_NAME, PublishToS3Task::class.java) {
+            it.publishedGroupId = extension.groupId
+            it.moduleName = extension.artifactId
+            it.finalizedBy(project.tasks.named("publishPluginMavenPublicationToMavenRepository"))
+        }
+
+        project.addFilterAndFinalizerToPublishToMavenRepositoryTasks(filterTask = PUBLISH_PLUGIN_TASK_NAME)
+    }
+}
+

--- a/plugin/src/test/kotlin/com/automattic/android/PublishPluginToS3PluginTest.kt
+++ b/plugin/src/test/kotlin/com/automattic/android/PublishPluginToS3PluginTest.kt
@@ -10,6 +10,8 @@ class PublishPluginToS3PluginTest {
     fun `plugin registers task`() {
         // Create a test project and apply the plugin
         val project = ProjectBuilder.builder().build()
+        // We expect every Gradle plugin to apply `java-gradle-plugin`
+        // https://docs.gradle.org/current/userguide/custom_plugins.html#sec:custom_plugins_standalone_project
         project.plugins.apply("java-gradle-plugin")
         project.plugins.apply("com.automattic.android.publish-plugin-to-s3")
 

--- a/plugin/src/test/kotlin/com/automattic/android/PublishPluginToS3PluginTest.kt
+++ b/plugin/src/test/kotlin/com/automattic/android/PublishPluginToS3PluginTest.kt
@@ -1,0 +1,26 @@
+package com.automattic.android.publish
+
+import org.gradle.testfixtures.ProjectBuilder
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertEquals
+
+class PublishPluginToS3PluginTest {
+    @Test
+    fun `plugin registers task`() {
+        // Create a test project and apply the plugin
+        val project = ProjectBuilder.builder().build()
+        project.plugins.apply("java-gradle-plugin")
+        project.plugins.apply("com.automattic.android.publish-plugin-to-s3")
+
+        // Verify the result
+        project.afterEvaluate {
+            /**
+             * "publishPluginMavenPublicationToMavenRepository" task is only available after the project is evaluated
+             * which causes the test to crash. We get around this issue by testing this task only
+             * after project is evaluated which matches the actual behaviour of the plugin.
+             */
+            assertNotNull(project.tasks.findByName("publishPluginToS3"))
+        }
+    }
+}


### PR DESCRIPTION
_This PR is part of a larger set of changes and should be treated as a step towards the goal of having multiple plugins handling different functionalities. I am splitting these up to make it easier to review the changes._

The main difference from library publishing plugin is that we don't need or want to add a publication for the components. This is already done from the `java-gradle-plugin`, so we just utilize the publication created from it.