### PR TITLE
Fixes publishing plugins and adds/refactors several tests

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.3"
+version = "0.3.1"
 
 dependencies {
     // Align versions of all Kotlin components

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java-gradle-plugin")
     id("org.jetbrains.kotlin.jvm") version "1.4.32"
-    id("io.gitlab.arturbosch.detekt").version("1.16.0")
+    id("io.gitlab.arturbosch.detekt").version("1.17.0")
     id("maven-publish")
 }
 

--- a/plugin/src/functionalTest/kotlin/com/automattic/android/CalculateVersionNameFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/automattic/android/CalculateVersionNameFunctionalTest.kt
@@ -16,21 +16,21 @@ private const val pullRequestUrl = "https://github.com/wordpress-mobile/WordPres
 class CalculateVersionNameFunctionalTest {
     @Test
     fun `fails for missing branch name`() {
-        val runner = publishToS3HelpersPluginFunctionalTestRunnerWithArguments("-q",
+        val runner = helpersPluginFunctionalTestRunner("-q",
             "calculateVersionName", "--sha1=$randomSha1")
         runner.buildAndFail()
     }
 
     @Test
     fun `fails for missing sha1`() {
-        val runner = publishToS3HelpersPluginFunctionalTestRunnerWithArguments("-q",
+        val runner = helpersPluginFunctionalTestRunner("-q",
             "calculateVersionName", "--branch-name=$randomBranchName")
         runner.buildAndFail()
     }
 
     @Test
     fun `returns {tagName} for non-empty tag`() {
-        val runner = publishToS3HelpersPluginFunctionalTestRunnerWithArguments("-q",
+        val runner = helpersPluginFunctionalTestRunner("-q",
             "calculateVersionName", "--branch-name=$developBranchName", "--sha1=$randomSha1",
             "--tag-name=$randomTagName")
         val result = runner.build()
@@ -39,7 +39,7 @@ class CalculateVersionNameFunctionalTest {
 
     @Test
     fun `returns {pullRequestNumber-sha1}`() {
-        val runner = publishToS3HelpersPluginFunctionalTestRunnerWithArguments("-q",
+        val runner = helpersPluginFunctionalTestRunner("-q",
             "calculateVersionName", "--branch-name=$developBranchName", "--sha1=$randomSha1",
             "--pull-request-url=$pullRequestUrl")
         val result = runner.build()
@@ -49,7 +49,7 @@ class CalculateVersionNameFunctionalTest {
     @Test
     fun `returns {branchName-sha1} for empty tag and empty pull request url`() {
         listOf(developBranchName, trunkBranchName, randomBranchName).forEach { branchName ->
-            val runner = publishToS3HelpersPluginFunctionalTestRunnerWithArguments("-q",
+            val runner = helpersPluginFunctionalTestRunner("-q",
                 "calculateVersionName", "--branch-name=$branchName", "--sha1=$randomSha1")
             val result = runner.build()
             val sanitizedBranchName = branchName.replace("/", "_")

--- a/plugin/src/functionalTest/kotlin/com/automattic/android/CheckS3VersionFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/automattic/android/CheckS3VersionFunctionalTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFalse
 class CheckS3VersionFunctionalTest {
     @Test
     fun `verify version exists`() {
-        val runner = publishToS3HelpersPluginFunctionalTestRunnerWithArguments("-q",
+        val runner = helpersPluginFunctionalTestRunner("-q",
             "isVersionPublishedToS3", "--version-name=1.40.0",
             "--published-group-id=org.wordpress", "--published-artifact-id=utils"
         )
@@ -19,7 +19,7 @@ class CheckS3VersionFunctionalTest {
 
     @Test
     fun `verify version does not exist`() {
-        val runner = publishToS3HelpersPluginFunctionalTestRunnerWithArguments("-q",
+        val runner = helpersPluginFunctionalTestRunner("-q",
             "isVersionPublishedToS3", "--version-name=thisversiondoesntexist",
             "--published-group-id=org.wordpress", "--published-artifact-id=utils"
         )

--- a/plugin/src/functionalTest/kotlin/com/automattic/android/FunctionalTestRunnerHelper.kt
+++ b/plugin/src/functionalTest/kotlin/com/automattic/android/FunctionalTestRunnerHelper.kt
@@ -3,20 +3,23 @@ package com.automattic.android.publish
 import java.io.File
 import org.gradle.testkit.runner.GradleRunner
 
-fun publishToS3HelpersPluginFunctionalTestRunnerWithArguments(vararg arguments: String): GradleRunner {
+fun helpersPluginFunctionalTestRunner(vararg arguments: String): GradleRunner =
+    functionalTestRunner("com.automattic.android.publish-to-s3-helpers", arguments.toList())
+
+private fun functionalTestRunner(pluginId: String, arguments: List<String>): GradleRunner {
     val projectDir = File("build/functionalTest")
     projectDir.mkdirs()
     projectDir.resolve("settings.gradle").writeText("")
     projectDir.resolve("build.gradle.kts").writeText("""
             plugins {
-                id("com.automattic.android.publish-to-s3-helpers")
+                id("$pluginId")
             }
         """)
 
     val runner = GradleRunner.create()
     runner.forwardOutput()
     runner.withPluginClasspath()
-    runner.withArguments(arguments.toList())
+    runner.withArguments(arguments)
     runner.withProjectDir(projectDir)
     return runner
 }

--- a/plugin/src/functionalTest/kotlin/com/automattic/android/FunctionalTestRunnerHelper.kt
+++ b/plugin/src/functionalTest/kotlin/com/automattic/android/FunctionalTestRunnerHelper.kt
@@ -6,6 +6,12 @@ import org.gradle.testkit.runner.GradleRunner
 fun helpersPluginFunctionalTestRunner(vararg arguments: String): GradleRunner =
     functionalTestRunner("com.automattic.android.publish-to-s3-helpers", arguments.toList())
 
+fun publishLibraryFunctionalTestRunner(vararg arguments: String): GradleRunner =
+    functionalTestRunner("com.automattic.android.publish-library-to-s3", arguments.toList())
+
+fun publishPluginFunctionalTestRunner(vararg arguments: String): GradleRunner =
+    functionalTestRunner("com.automattic.android.publish-plugin-to-s3", arguments.toList())
+
 private fun functionalTestRunner(pluginId: String, arguments: List<String>): GradleRunner {
     val projectDir = File("build/functionalTest")
     projectDir.mkdirs()

--- a/plugin/src/functionalTest/kotlin/com/automattic/android/ListAllTasksFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/automattic/android/ListAllTasksFunctionalTest.kt
@@ -1,0 +1,24 @@
+package com.automattic.android.publish
+
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class ListAllTasksFunctionalTest {
+    @Test
+    fun `lists all publish helpers tasks`() {
+        helpersPluginFunctionalTestRunner("-q", "tasks", "--all").build()
+    }
+
+    @Test
+    fun `lists all publish library tasks`() {
+        publishLibraryFunctionalTestRunner("-q", "tasks", "--all").build()
+    }
+
+    @Test
+    fun `lists all publish plugin tasks`() {
+        publishPluginFunctionalTestRunner("-q", "tasks", "--all").build()
+    }
+}

--- a/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Plugin.kt
@@ -8,6 +8,7 @@ private const val PUBLISH_PLUGIN_TASK_NAME = "publishPluginToS3"
 class PublishPluginToS3Plugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.plugins.apply("maven-publish")
+        project.plugins.apply("java-gradle-plugin")
 
         val extension = project.extensions.create("s3PublishPlugin", PublishPluginToS3Extension::class.java)
         project.setupS3Repository()
@@ -15,7 +16,7 @@ class PublishPluginToS3Plugin : Plugin<Project> {
         project.tasks.register(PUBLISH_PLUGIN_TASK_NAME, PublishToS3Task::class.java) {
             it.publishedGroupId = extension.groupId
             it.moduleName = extension.artifactId
-            it.finalizedBy(project.tasks.named("publishPluginMavenPublicationToMavenRepository"))
+            it.finalizedBy(project.tasks.named("publishPluginMavenPublicationToS3Repository"))
         }
 
         project.addFilterAndFinalizerToPublishToMavenRepositoryTasks(filterTask = PUBLISH_PLUGIN_TASK_NAME)

--- a/plugin/src/test/kotlin/com/automattic/android/PublishPluginToS3PluginTest.kt
+++ b/plugin/src/test/kotlin/com/automattic/android/PublishPluginToS3PluginTest.kt
@@ -10,15 +10,12 @@ class PublishPluginToS3PluginTest {
     fun `plugin registers task`() {
         // Create a test project and apply the plugin
         val project = ProjectBuilder.builder().build()
-        // We expect every Gradle plugin to apply `java-gradle-plugin`
-        // https://docs.gradle.org/current/userguide/custom_plugins.html#sec:custom_plugins_standalone_project
-        project.plugins.apply("java-gradle-plugin")
         project.plugins.apply("com.automattic.android.publish-plugin-to-s3")
 
         // Verify the result
         project.afterEvaluate {
             /**
-             * "publishPluginMavenPublicationToMavenRepository" task is only available after the project is evaluated
+             * "publishPluginMavenPublicationToS3Repository" task is only available after the project is evaluated
              * which causes the test to crash. We get around this issue by testing this task only
              * after project is evaluated which matches the actual behaviour of the plugin.
              */


### PR DESCRIPTION
This PR fixes an error with publishing a plugin. We were relying on `publishPluginMavenPublicationToMavenRepository` gradle task to finish publishing the plugin whereas it should have been `publishPluginMavenPublicationToS3Repository` because of [this](https://github.com/Automattic/publish-to-s3-gradle-plugin/blob/trunk/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt#L30). This issue came up as soon as I was trying to add it to the [configure plugin](https://github.com/Automattic/configure/pull/14) since even listing the gradle tasks failed `./gradlew tasks --all`, so I've added functional tests to catch these basic issues.

I've also added `java-gradle-plugin` to be a dependency of our plugin, updated `detekt` version as the old one was causing a failure and refactored the existing tests.

The project is still considered a work in progress and improvements are being made in incremental steps.