### PR TITLE
Set java compatibility to java 8

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -41,6 +41,11 @@ gradlePlugin {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 // Add a source set for the functional test suite
 val functionalTestSourceSet = sourceSets.create("functionalTest")
 gradlePlugin.testSourceSets(functionalTestSourceSet)

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.3.1"
+version = "0.4.0"
 
 dependencies {
     // Align versions of all Kotlin components


### PR DESCRIPTION
We have had [couple reports](https://github.com/wordpress-mobile/WordPress-Android/pull/14695#pullrequestreview-666573809) where developers had the error below. I've not had this error myself and haven't seen it in CI, so it went unnoticed so far. My understanding is that this is happening because this project is using a different version of Java and [this check](https://docs.gradle.org/current/userguide/upgrading_version_5.html#automatic_target_jvm_version) is not liking that. I've considered setting java version to 11 across projects, but that creates some errors and I _think_ it requires Gradle 7.0 and Android Gradle Plugin 4.2.

Long story short, this PR sets the java compatibility to java 8 so it's consistent with other projects and we don't have the error below.

```
A problem occurred configuring project ':WordPress-Utils-Android:WordPressUtils'.
> Could not resolve all artifacts for configuration ':WordPress-Utils-Android:WordPressUtils:classpath'.
   > Could not resolve com.automattic.android:publish-to-s3:0.2.2.
     Required by:
         project :WordPress-Utils-Android:WordPressUtils
      > Unable to find a matching variant of com.automattic.android:publish-to-s3:0.2.2:
          - Variant 'apiElements' capability com.automattic.android:publish-to-s3:0.2.2:
              - Incompatible attributes:
                  - Required org.gradle.jvm.version '8' and found incompatible value '11'.
                  - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api'.
              - Other attributes:
                  - Found org.gradle.category 'library' but wasn't required.
                  - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
                  - Required org.gradle.libraryelements 'jar' and found compatible value 'jar'.
                  - Found org.gradle.status 'release' but wasn't required.
                  - Found org.jetbrains.kotlin.localToProject 'public' but wasn't required.
                  - Found org.jetbrains.kotlin.platform.type 'jvm' but wasn't required.
          - Variant 'runtimeElements' capability com.automattic.android:publish-to-s3:0.2.2:
              - Incompatible attribute:
                  - Required org.gradle.jvm.version '8' and found incompatible value '11'.
              - Other attributes:
                  - Found org.gradle.category 'library' but wasn't required.
                  - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
                  - Required org.gradle.libraryelements 'jar' and found compatible value 'jar'.
                  - Found org.gradle.status 'release' but wasn't required.
                  - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime'.
                  - Found org.jetbrains.kotlin.localToProject 'public' but wasn't required.
                  - Found org.jetbrains.kotlin.platform.type 'jvm' but wasn't required.
```