### PR TITLE
Update artifact id for plugins

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.4.0"
+version = "0.4.1"
 
 dependencies {
     // Align versions of all Kotlin components

--- a/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
@@ -24,6 +24,14 @@ fun Project.setVersionForAllMavenPublications(versionName: String) {
         }
 }
 
+fun Project.setArtifactIdForAllMavenPublications(artifactId: String?) {
+    if (artifactId.isNullOrEmpty()) return
+    project.getExtensions().getByType(PublishingExtension::class.java)
+        .publications.withType(MavenPublication::class.java).forEach {
+            it.artifactId = artifactId
+        }
+}
+
 fun Project.setupS3Repository() {
     project.getExtensions().configure(PublishingExtension::class.java) { publishing ->
         publishing.repositories.maven { mavenRepo ->

--- a/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
@@ -13,9 +13,7 @@ fun Project.setExtraVersionName(versionName: String) {
     project.extraProperties.set(EXTRA_VERSION_NAME, versionName)
 }
 
-fun Project.getExtraVersionName() {
-    project.extraProperties.get(EXTRA_VERSION_NAME)
-}
+fun Project.getExtraVersionName() = project.extraProperties.get(EXTRA_VERSION_NAME)
 
 fun Project.setVersionForAllMavenPublications(versionName: String) {
     project.getExtensions().getByType(PublishingExtension::class.java)

--- a/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Plugin.kt
@@ -16,6 +16,8 @@ class PublishPluginToS3Plugin : Plugin<Project> {
         project.tasks.register(PUBLISH_PLUGIN_TASK_NAME, PublishToS3Task::class.java) {
             it.publishedGroupId = extension.groupId
             it.moduleName = extension.artifactId
+            // Since plugin publication is created by `java-gradle-plugin` we need to manually change its artifact id
+            project.setArtifactIdForAllMavenPublications(extension.artifactId)
             it.finalizedBy(project.tasks.named("publishPluginMavenPublicationToS3Repository"))
         }
 


### PR DESCRIPTION
This PR fixes 2 issues:
1. [artifactId](https://github.com/Automattic/publish-to-s3-gradle-plugin/blob/trunk/plugin/src/main/kotlin/com/automattic/android/PublishPluginToS3Extension.kt#L5) was not being set for plugins because the publication is created by `java-gradle-plugin`. It was using the project name for it and so far in my tests I was setting the `artifactId` to the project name, so this went unnoticed. I've fixed this in a non-ideal way, but I have an issue that should improve it when I can get to it. https://github.com/Automattic/publish-to-s3-gradle-plugin/issues/14
2. `Project.getExtraVersionName` was not returning the value 🤦 which ended up printing `'kotlin.Unit' is succesfully published.` which is not very useful.

@jkmassel @mokagio  I am assigning this review to you two, but since it's a blocker for me, I'll merge it in immediately. I am happy to address any feedback as a separate PR, so I'd still appreciate a review.

_P.S: There is much I'd like to improve in this project, but in all due time 🤞_ 