### PR TITLE
Update readme for 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://developer.android.com/studio/build/maven-publish-plugin
 
 The plugin applies & configures the `maven-publish` plugin by adding the S3 repository as well as a `MavenPublication` that uses the calculated version name. It provides 3 Gradle tasks:
 
-* `publishLibraryToS3` takes `--branch-name`, `--sha1`, `--tag-name` & `--pull-request-url` command line arguments and uses the information to calculate a version name, verify that this version is not already published to S3 and finally calls `publishS3PublicationToS3Repository` gradle task which will publish the artifacts to S3.
+* `publishLibraryToS3` can take a mix of the following command line arguments: `--branch-name`, `--sha1`, `--tag-name`, `--pull-request-url`. Depending on the arguments passed, it uses the information to calculate a version name (see below), verify that this version is not already published to S3 and finally calls `publishS3PublicationToS3Repository` gradle task which will publish the artifacts to S3.
 * `calculateVersionName` takes `--branch-name`, `--sha1`, `--tag-name` & `--pull-request-url` command line arguments and prints the calculated version name.
 * `isVersionPublishedToS3` takes  `--version-name` command line argument and combines it with the `groupId` & `artifactId` values from the extension to check if it's already published to S3.
 
@@ -62,4 +62,3 @@ Unfortunately, we are currently unable to utilize the [Plugin DSL](https://docs.
 The gist of the issue is that Gradle is looking for a JAR file for the [Plugin Marker Artifact](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers) even though it should only utilize its dependencies.
 [As explained by one of Gradle developers](https://github.com/gradle/gradle/issues/8754#issuecomment-474011765), there is currently no way to get around these extra requests.
 Since S3 returns 403 status code for nonexistent files, the build results in failure.
-

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ We used to store our artifacts in JCenter, but since [Bintray was shutdown](http
 
 In the library's main module's `build.gradle` file:
 
-```
+```groovy
 buildscript {
     repositories {
         maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
     }
     dependencies {
-        classpath 'com.automattic.android:publish-to-s3:0.2'
+        classpath 'com.automattic.android:publish-to-s3:0.4.1'
     }
 }
 
-apply plugin: 'com.automattic.android.publish-to-s3'
+apply plugin: 'com.automattic.android.publish-library-to-s3'
 
-s3PublishPlugin {
+s3PublishLibrary {
     groupId = "{groupId}"
     artifactId = "{artifactId}"
     from = "release" // component name
@@ -39,7 +39,7 @@ https://developer.android.com/studio/build/maven-publish-plugin
 
 The plugin applies & configures the `maven-publish` plugin by adding the S3 repository as well as a `MavenPublication` that uses the calculated version name. It provides 3 Gradle tasks:
 
-* `publishToS3` takes `--branch-name`, `--sha1`, `--tag-name` & `--pull-request-url` command line arguments and uses the information to calculate a version name, verify that this version is not already published to S3 and finally calls `publishS3PublicationToS3Repository` gradle task which will publish the artifacts to S3.
+* `publishLibraryToS3` takes `--branch-name`, `--sha1`, `--tag-name` & `--pull-request-url` command line arguments and uses the information to calculate a version name, verify that this version is not already published to S3 and finally calls `publishS3PublicationToS3Repository` gradle task which will publish the artifacts to S3.
 * `calculateVersionName` takes `--branch-name`, `--sha1`, `--tag-name` & `--pull-request-url` command line arguments and prints the calculated version name.
 * `isVersionPublishedToS3` takes  `--version-name` command line argument and combines it with the `groupId` & `artifactId` values from the extension to check if it's already published to S3.
 


### PR DESCRIPTION
It also fixes the outdated information about installation and usage. This PR still doesn't add instructions for how to publish a plugin which will be handled separately. I am just not sure how yet. I don't want to crowd the README, so maybe we should split it up. Alternatively, we can add everything to README, but have a `Table of Contents` at the top, so it'll be easier to navigate. Either way, I don't think this work is very urgent - I just want to fix incorrect information in this PR.