### PR TITLE
Github Actions for Testing & Handle 404 error in s3 version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ trunk ]
+  pull_request:
+    branches: [ trunk ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: wordpressmobile/android-build-image
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test
+      run: ./gradlew :plugin:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
     container:
       image: wordpressmobile/android-build-image
     steps:
-    - uses: actions/checkout@v2
-    - name: Test
-      run: ./gradlew :plugin:check
+      - uses: actions/checkout@v2
+      - name: Test
+        run: ./gradlew :plugin:check

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.4.1"
+version = "0.4.2"
 
 dependencies {
     // Align versions of all Kotlin components

--- a/plugin/src/main/kotlin/com/automattic/android/CheckS3Version.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/CheckS3Version.kt
@@ -4,7 +4,8 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 private const val SUCCESS_STATUS_CODE = 200
-private const val FAILURE_STATUS_CODE = 403
+private const val FORBIDDEN_STATUS_CODE = 403
+private const val FAILURE_STATUS_CODE = 404
 
 class CheckS3Version(
     val publishedGroupId: String,
@@ -32,7 +33,8 @@ class CheckS3Version(
     fun check(): Boolean =
         when (responseCodeForUrl(pomUrl)) {
             SUCCESS_STATUS_CODE -> true
-            FAILURE_STATUS_CODE -> false
+            // Dependending on ACL settings S3 may return 403 or 404 for a missing file
+            FAILURE_STATUS_CODE, FORBIDDEN_STATUS_CODE -> false
             else -> throw IllegalStateException(unexpectedStatusCodeMessage)
         }
 


### PR DESCRIPTION
This PR adds a basic Github action that runs `./gradlew :plugin:check` which is a combination of all tests and lint tasks.

It also adds support for handling 404 errors from S3 while checking if a version exists. We have recently changed the ACL settings for our S3 repository to return 404 instead of 403 for plugin marker artifact support. This caused our version checks to fail which this PR addresses.

**To test:**
* Run `./gradlew :plugin:check` in `trunk` and verify that it fails
* Run `./gradlew :plugin:check` in this branch and verify that it passes

Alternatively, you can use the Github Actions logs & status check 🥳 