### PR TITLE
Create a published-version file in buildDir after successful publish

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.6.0"
+version = "0.6.1"
 
 dependencies {
     // Align versions of all Kotlin components

--- a/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
@@ -1,5 +1,6 @@
 package com.automattic.android.publish
 
+import java.io.File
 import java.net.URI
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -38,6 +39,8 @@ fun Project.addS3MavenRepository() {
 fun Project.printPublishedVersionNameAfterPublishTasks() {
     project.tasks.withType(PublishToMavenRepository::class.java) { task ->
         task.doLast {
+            File(project.buildDir, "published-version.txt").writeText("${project.getExtraVersionName()}")
+
             println("'${project.getExtraVersionName()}' is succesfully published.")
         }
     }


### PR DESCRIPTION
When we are publishing multiple artifacts consecutively and one depends on the other, we need to read the published version name. This change should make that easy.