### PR TITLE
Add androidSourcesJar task and remove `publishToS3Plugin` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ publishing {
             artifactId = 'library'
             // version is set by `publish-to-s3` plugin in `prepareToPublishToS3` task, so it should be omitted
 
-            // This can be used for android library projects to upload the source files
+            // This can be used for Android library projects to upload the source files
             // artifact tasks.named("androidSourcesJar")
 
             from components.java 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ buildscript {
         maven { url 'https://a8c-libs.s3.amazonaws.com/android' }
     }
     dependencies {
-        classpath 'com.automattic.android:publish-to-s3:0.6.1'
+        classpath 'com.automattic.android:publish-to-s3:0.7.0'
     }
 }
 
@@ -29,15 +29,12 @@ publishing {
             artifactId = 'library'
             // version is set by `publish-to-s3` plugin in `prepareToPublishToS3` task, so it should be omitted
 
+            // This can be used for android library projects to upload the source files
+            // artifact tasks.named("androidSourcesJar")
+
             from components.java 
         }
     }
-}
-
-// This extension is currently necessary to check if the version is already published. It should match the information in MavenPublication
-publishToS3Plugin {
-    mavenPublishGroupId = 'org.gradle.sample'
-    mavenPublishArtifactId = 'library' 
 }
 ```
 
@@ -58,7 +55,7 @@ Here are the available command line arguments: `--tag-name`, `--pull-request-num
 The plugin also provides the following helper tasks:
 
 * `calculateVersionName` takes the same `--branch-name`, `--sha1`, `--tag-name` & `--pull-request-number` command line arguments and prints the calculated version name.
-* `isVersionPublishedToS3` takes  `--version-name` command line argument and combines it with the `mavenPublishGroupId` & `mavenPublishArtifactId` values from the extension to check if it's already published to S3.
+* `isVersionPublishedToS3` takes  `--version-name` command line argument and verifies that none of the publications defined for the module has already been published to S3.
 
 ### Notes
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,12 +7,15 @@ plugins {
 
 repositories {
     mavenCentral()
+    google()
 }
 
 group = "com.automattic.android"
 version = "0.6.1"
 
 dependencies {
+    compileOnly("com.android.tools.build:gradle:4.2.2")
+
     // Align versions of all Kotlin components
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.6.1"
+version = "0.7.0"
 
 dependencies {
     compileOnly("com.android.tools.build:gradle:4.2.2")

--- a/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/ProjectExtensions.kt
@@ -17,11 +17,14 @@ fun Project.setExtraVersionName(versionName: String) {
 fun Project.getExtraVersionName() = project.extraProperties.get(EXTRA_VERSION_NAME)
 
 fun Project.setVersionForAllMavenPublications(versionName: String) {
-    project.getExtensions().getByType(PublishingExtension::class.java)
-        .publications.withType(MavenPublication::class.java).forEach {
-            it.version = versionName
-        }
+    project.allMavenPublications().forEach {
+        it.version = versionName
+    }
 }
+
+fun Project.allMavenPublications() =
+    project.getExtensions().getByType(PublishingExtension::class.java)
+        .publications.withType(MavenPublication::class.java)
 
 fun Project.addS3MavenRepository() {
     project.getExtensions().configure(PublishingExtension::class.java) { publishing ->

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Extension.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Extension.kt
@@ -1,6 +1,0 @@
-package com.automattic.android.publish
-
-interface PublishToS3Extension {
-    var mavenPublishGroupId: String
-    var mavenPublishArtifactId: String
-}

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
@@ -15,7 +15,7 @@ class PublishToS3Plugin : Plugin<Project> {
         project.tasks.register("calculateVersionName", CalculateVersionNameTask::class.java)
         project.tasks.register("isVersionPublishedToS3", CheckS3VersionTask::class.java)
 
-        if (project.pluginManager.hasPlugin("com.android.library")) {
+        project.pluginManager.withPlugin("com.android.library") {
             project.extensions.findByType(LibraryExtension::class.java)?.let { androidLibrary ->
                 androidLibrary.sourceSets.findByName("main")?.let { mainSourceSet ->
                     project.tasks.register("androidSourcesJar", Jar::class.java) { task ->

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
@@ -19,6 +19,8 @@ class PublishToS3Plugin : Plugin<Project> {
             project.extensions.findByType(LibraryExtension::class.java)?.let { androidLibrary ->
                 androidLibrary.sourceSets.findByName("main")?.let { mainSourceSet ->
                     project.tasks.register("androidSourcesJar", Jar::class.java) { task ->
+                        task.description = "Creates a jar from android library main source set " +
+                            "to be used to publish the '-sources.jar' file with the library artifacts"
                         task.from(mainSourceSet.java.srcDirs)
                         task.archiveClassifier.set("sources")
                     }

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
@@ -4,6 +4,8 @@ import org.gradle.api.Project
 import org.gradle.api.Plugin
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.gradle.jvm.tasks.Jar
+import com.android.build.gradle.LibraryExtension
 
 class PublishToS3Plugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -12,6 +14,17 @@ class PublishToS3Plugin : Plugin<Project> {
 
         project.tasks.register("calculateVersionName", CalculateVersionNameTask::class.java)
         project.tasks.register("isVersionPublishedToS3", CheckS3VersionTask::class.java)
+
+        if (project.pluginManager.hasPlugin("com.android.library")) {
+            project.extensions.findByType(LibraryExtension::class.java)?.let { androidLibrary ->
+                androidLibrary.sourceSets.findByName("main")?.let { mainSourceSet ->
+                    project.tasks.register("androidSourcesJar", Jar::class.java) { task ->
+                        task.from(mainSourceSet.java.srcDirs)
+                        task.archiveClassifier.set("sources")
+                    }
+                }
+            }
+        }
 
         val extension = project.extensions.create("publishToS3Plugin", PublishToS3Extension::class.java)
         val preTask = project.tasks.register("prepareToPublishToS3", PrepareToPublishToS3Task::class.java) { task ->

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
@@ -19,7 +19,7 @@ class PublishToS3Plugin : Plugin<Project> {
             project.extensions.findByType(LibraryExtension::class.java)?.let { androidLibrary ->
                 androidLibrary.sourceSets.findByName("main")?.let { mainSourceSet ->
                     project.tasks.register("androidSourcesJar", Jar::class.java) { task ->
-                        task.description = "Creates a jar from android library main source set " +
+                        task.description = "Creates a jar from Android library main source set " +
                             "to be used to publish the '-sources.jar' file with the library artifacts"
                         task.from(mainSourceSet.java.srcDirs)
                         task.archiveClassifier.set("sources")

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
@@ -26,12 +26,7 @@ class PublishToS3Plugin : Plugin<Project> {
             }
         }
 
-        val extension = project.extensions.create("publishToS3Plugin", PublishToS3Extension::class.java)
-        val preTask = project.tasks.register("prepareToPublishToS3", PrepareToPublishToS3Task::class.java) { task ->
-            task.publishedGroupId = extension.mavenPublishGroupId
-            task.moduleName = extension.mavenPublishArtifactId
-        }
-
+        val preTask = project.tasks.register("prepareToPublishToS3", PrepareToPublishToS3Task::class.java)
         project.tasks.withType(PublishToMavenRepository::class.java) { task ->
             task.dependsOn(preTask)
         }


### PR DESCRIPTION
We'd like to start publishing `-sources.jar` file for the library artifacts we are publishing so that developers can check the source code within their IDEs when the artifact is added as a binary dependency. This PR adds an `androidSourcesJar` to Android library projects, so it can be used to publish the `-sources.jar` file along with the library artifacts. It also removes the need for `publishToS3Plugin` extension.

**To test:**

You can see how this PR is applied in https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/95 & https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2160 and test it in https://github.com/wordpress-mobile/WordPress-Android/pull/15492.

---

Here is how we'd typically setup a module to support uploading `-sources.jar` artifact for an Android library:

```groovy
tasks.register("androidSourcesJar", Jar) {
    from android.sourceSets.main.java.srcDirs
    classifier "sources"
}

publishing {
    publications {
        Publication(MavenPublication) {
            // ...

            artifact tasks.named("androidSourcesJar")
        }
    }
}
```

What this PR does is register that same task for every Android library project, meaning projects with `com.android.library` plugin applied, so we don't have to create this task for each project. Note that, it is possible to add the artifact to the publication as well, however I am currently trying to leave the publications unchanged except for the version information so as to not break the current transparency we have. Also, the earlier iterations of the plugin did a bit too much and with the diverse projects we have, it ended up hurting us as we had to go back to the plugin and change/fix things. Keeping it simple like this has no major downside and we always have to option to improve things when we have more confidence in it. Which brings me to:

`publishToS3Plugin` extension was added to combat the plugin doing too much as I wanted to make sure the information we'd read from the current publications would be correct. I think we are at a point that our setup settled down quite a bit and we have more confidence in how it's used across projects. So, I've removed the need for `publishToS3Plugin` extension. This extension was used for checking whether a specific version was already published which is now done by going through all publications in a module (which there will only be one in most cases) and checking each of them. In practice this ends up working exactly the same way.

---

The only thing I couldn't get to work in this PR is the functional test for checking if the `androidSourcesJar` is correctly added for android library projects. I've tried everything I can think of and even though I could verify everything works for the functional test when I manually run the gradle commands in the test project that I am creating, I can't get `GradleRunner` to work with it. Instead of leaving the functional test I had in a branch, I am going to leave it in the PR description and hope that one day I can come back to it and figure out what I missed:

```kt
package com.automattic.android.publish

import java.io.File
import org.gradle.testkit.runner.GradleRunner
import kotlin.test.Test
import kotlin.test.assertTrue
import kotlin.test.assertFalse

class AndroidSourcesJarTaskFunctionalTest {
    @Test
    fun `non android library project does not register androidSourcesJar task`() {
        functionalTestRunner("-q", "androidSourcesJar").buildAndFail()
    }

    @Test
    fun `android library project registers androidSourcesJar task`() {
        val projectDir = File("build/functionalTest/androidSourcesJarTaskTest")
        projectDir.mkdirs()
        projectDir.resolve("settings.gradle").writeText("""
                pluginManagement {
                    repositories {
                        gradlePluginPortal()
                        google()
                    }
                }
            """)
        projectDir.resolve("build.gradle").writeText("""
                plugins {
                    id("com.android.library") version "4.2.2"
                    id("com.automattic.android.publish-to-s3")
                }
            """)

        GradleRunner.create()
            .forwardOutput()
            .withPluginClasspath()
            .withArguments("-q", "tasks", "--all")
            .withProjectDir(projectDir)
            .build()
    }
}
```

This results in:

```
* What went wrong:
com/android/build/gradle/LibraryExtension
> com.android.build.gradle.LibraryExtension
```