### PR TITLE
Adds `publish-to-s3-without-sources` plugin

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "com.automattic.android"
-version = "0.8.0"
+version = "0.9.0-rc-25"
 
 dependencies {
     compileOnly("com.android.tools.build:gradle:7.2.1")
@@ -33,6 +33,10 @@ gradlePlugin {
     plugins.register("publish-to-s3") {
         id = "com.automattic.android.publish-to-s3"
         implementationClass = "com.automattic.android.publish.PublishToS3Plugin"
+    }
+    plugins.register("publish-to-s3-without-sources") {
+        id = "com.automattic.android.publish-to-s3-without-sources"
+        implementationClass = "com.automattic.android.publish.PublishToS3WithoutSourcesPlugin"
     }
 }
 

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
@@ -8,7 +8,7 @@ import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 
 class PublishToS3Plugin : Plugin<Project> {
     override fun apply(project: Project) {
-        applyInternal(project)
+        applyInternal(project, withSources = true)
     }
 }
 
@@ -18,7 +18,7 @@ class PublishToS3WithoutSourcesPlugin : Plugin<Project> {
     }
 }
 
-private fun applyInternal(project: Project, withSources: Boolean = true) {
+private fun applyInternal(project: Project, withSources: Boolean) {
     project.plugins.apply("maven-publish")
     project.addS3MavenRepository()
 
@@ -28,9 +28,7 @@ private fun applyInternal(project: Project, withSources: Boolean = true) {
     project.pluginManager.withPlugin("com.android.library") {
         project.extensions.findByType(LibraryExtension::class.java)?.let { androidLibrary ->
             androidLibrary.publishing.singleVariant("release") {
-                if (withSources) {
-                    withSourcesJar()
-                }
+                if (withSources) withSourcesJar()
                 withJavadocJar()
             }
         }

--- a/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/PublishToS3Plugin.kt
@@ -1,37 +1,48 @@
 package com.automattic.android.publish
 
+import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Project
 import org.gradle.api.Plugin
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
-import org.gradle.jvm.tasks.Jar
-import com.android.build.gradle.LibraryExtension
 
 class PublishToS3Plugin : Plugin<Project> {
     override fun apply(project: Project) {
-        project.plugins.apply("maven-publish")
-        project.addS3MavenRepository()
+        applyInternal(project)
+    }
+}
 
-        project.tasks.register("calculateVersionName", CalculateVersionNameTask::class.java)
-        project.tasks.register("isVersionPublishedToS3", CheckS3VersionTask::class.java)
+class PublishToS3WithoutSourcesPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        applyInternal(project, withSources = false)
+    }
+}
 
-        project.pluginManager.withPlugin("com.android.library") {
-            project.extensions.findByType(LibraryExtension::class.java)?.let { androidLibrary ->
-                androidLibrary.publishing.singleVariant("release") {
+private fun applyInternal(project: Project, withSources: Boolean = true) {
+    project.plugins.apply("maven-publish")
+    project.addS3MavenRepository()
+
+    project.tasks.register("calculateVersionName", CalculateVersionNameTask::class.java)
+    project.tasks.register("isVersionPublishedToS3", CheckS3VersionTask::class.java)
+
+    project.pluginManager.withPlugin("com.android.library") {
+        project.extensions.findByType(LibraryExtension::class.java)?.let { androidLibrary ->
+            androidLibrary.publishing.singleVariant("release") {
+                if (withSources) {
                     withSourcesJar()
-                    withJavadocJar()
                 }
+                withJavadocJar()
             }
         }
-
-        val preTask = project.tasks.register("prepareToPublishToS3", PrepareToPublishToS3Task::class.java)
-        project.tasks.withType(PublishToMavenRepository::class.java) { task ->
-            task.dependsOn(preTask)
-        }
-        project.tasks.withType(GenerateMavenPom::class.java) { task ->
-            task.dependsOn(preTask)
-        }
-
-        project.printPublishedVersionNameAfterPublishTasks()
     }
+
+    val preTask = project.tasks.register("prepareToPublishToS3", PrepareToPublishToS3Task::class.java)
+    project.tasks.withType(PublishToMavenRepository::class.java) { task ->
+        task.dependsOn(preTask)
+    }
+    project.tasks.withType(GenerateMavenPom::class.java) { task ->
+        task.dependsOn(preTask)
+    }
+
+    project.printPublishedVersionNameAfterPublishTasks()
 }


### PR DESCRIPTION
This PR adds a new plugin, `publish-to-s3-without-sources`, that we'll publish alongside the `publish-to-s3` plugin. They work exactly the same way, except that `publish-to-s3-without-sources` will not publish the sources - as I hope is clear from its name.

In https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/31, I've added support for publishing sources and javadoc for our libraries without requiring any configuration from them. However, I forgot the fact that we don't want to publish the sources for every library.

In https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/32, I initially explored adding a plugin extension to control publishing the sources and javadoc. I wanted the extension to be optional and default to `true`, however I couldn't get that setup to work. My understanding is that, in `Plugin`'s `apply`, we shouldn't read the value of the extension and should map it instead. That setup works for a task, but doesn't work for something that needs to be done in the configuration phase. I checked if we could maybe do it in `afterEvaluate`, but AGP doesn't allow changing the publishing setup after configuration is done. In the end, I abandoned that approach.

Although this PR is updating the version number to `rc-25`, yes it took embarrassingly long to get a setup that I like to work, the implementation changes in this PR are _very_ simple. Also, I really like this approach of publishing two different plugins, one that publishes the source and one that doesn't. It should make it very easy to identify the behavior of the plugin at a glance without having to find the plugin's extension, which most developers wouldn't be aware of.

**To Test**

**Verify sources are published before the change**

* Clone or update `trunk` of [`WordPress-Utils-Android`](https://github.com/wordpress-mobile/wordpress-utils-android) in your local environment
* Optionally, delete `~/.m2` folder which is the `mavenLocal` folder
* Run `./gradlew :WordPressUtils:prepareToPublishToS3 --tag-name 21.0 :WordPressUtils:publishToMavenLocal` - Use a tag name that hasn't been published before. If you deleted the `~/.m2` folder, you can use any name.
* Verify that the sources are published to: `~/.m2/repository/org/wordpress/utils/21.0/utils-21.0-sources.jar`

**Verify that sources are published after the change**

* Change the plugin version to `0.9.0-rc-25` [here](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/trunk/settings.gradle#L4)
* Run `./gradlew :WordPressUtils:prepareToPublishToS3 --tag-name 22.0 :WordPressUtils:publishToMavenLocal` - use a different version number from the previous step
* Verify that the sources are published to: `~/.m2/repository/org/wordpress/utils/22.0/utils-22.0-sources.jar`

**Verify that sources are not published using `publish-to-s3-without-sources` plugin**

* Discard the changes and checkout the `update/publish-to-s3-plugin-to-0.9.0` branch from https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/131
* Run `./gradlew :WordPressUtils:prepareToPublishToS3 --tag-name 23.0 :WordPressUtils:publishToMavenLocal` - use a different version number from the previous steps
* Verify that the sources are NOT published to: `~/.m2/repository/org/wordpress/utils/23.0/utils-23.0-sources.jar`

**Quick Tip**

I use `exa --tree ~/.m2` to quickly print out the folder structure of the local maven repository. Other tools also have the `tree` ability, but I've been using [`exa`](https://github.com/ogham/exa) for all my `ls` operations for years and I've been very happy with it. Here are my mappings for fish terminal:

```
abbr --add ls exa
abbr --add ll exa -l
abbr --add tree exa --tree
```