### PR TITLE
feat: update version of `dependency` node of marker artifact

### DIFF
--- a/plugin/src/main/kotlin/com/automattic/android/publish/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/automattic/android/publish/ProjectExtensions.kt
@@ -5,6 +5,7 @@ import org.gradle.api.credentials.AwsCredentials
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.w3c.dom.Element
 import java.io.File
 import java.net.URI
 
@@ -19,6 +20,22 @@ fun Project.getExtraVersionName() = project.extraProperties.get(EXTRA_VERSION_NA
 fun Project.setVersionForAllMavenPublications(versionName: String) {
     project.allMavenPublications().forEach {
         it.version = versionName
+        if (it.name.endsWith("PluginMarkerMaven")) {
+            it.updatePluginMarkerPom(versionName)
+        }
+    }
+}
+
+private fun MavenPublication.updatePluginMarkerPom(
+    versionName: String
+) {
+    pom.withXml { xmlProvider ->
+        val root: Element = xmlProvider.asElement()
+        val versionTags = root.getElementsByTagName("version")
+
+        for (i in 0..versionTags.length - 1) {
+            versionTags.item(i).textContent = versionName
+        }
     }
 }
 


### PR DESCRIPTION
Closes: #35 

### Description

This PR makes plugin work for publishing other Gradle plugins, by setting the correct version of the `dependency.version` tag on plugin marker's POM file.

### How?

While using `pulbish-to-s3-gradle-plugin` on a Gradle plugin, the current flow of events is following:
1. **During the configuration phase**, the [`MavenPluginPublishPlugin`](https://github.com/gradle/gradle/blob/master/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java) creates a new `MavenPublication` named `<developed_plugin>PluginMarkerMaven`. To each new publication, it creates a new `.pom` file with `version` being equal to the current version of plugin declared in `gradlePlugin { }` extension. For users of `publish-to-s3-gradle-plugin` this value is `null` at the time of configuration phase.
2. Later, when `publish-to-s3-gradle-plugin` executes its tasks in build phase, it [sets the calculated version](https://github.com/Automattic/publish-to-s3-gradle-plugin/blob/trunk/plugin/src/main/kotlin/com/automattic/android/publish/ProjectExtensions.kt#L19C17-L19C17) on all `MavenPublication` instances, **but it does not update generated `.pom` files**.

This PR adds a change that `PrepareToPublishToS3Task` will update versions of not only `MavenPublication` instances, but, if the publication is a `PluginMarkerMaven`, also `.pom` file.

### Testing

As a test object, I've used [measure-builds-gradle-plugin](https://github.com/Automattic/measure-builds-gradle-plugin) on branch `issue/publishing-tests` and added `publish-to-s3-gradle-plugin` as `includedBuild` by adding `includeBuild("../../publish-to-s3-gradle-plugin")` in `plugin/settings.gradle.kts`. It forced me to update Kotlin to `1.9.10` and source compatibility to Java 17 of this project of `publish-to-s3-gradle-plugin`.

It requires some overhead that I don't like, but couldn't find a better way.

#### Using `mavenLocal`

1. Check out `trunk` of `publish-to-s3-gradle-plugin` repository, 
2. Inside `measure-builds-gradle-plugin` repository run `./gradlew :plugin:prepareToPublishToS3 --tag-name="custom_tag" :plugin:publishToMavenLocal`
3. Open `cat ~/.m2/repository/com/automattic/android/measure-builds/com.automattic.android.measure-builds.gradle.plugin/custom_tag/com.automattic.android.measure-builds.gradle.plugin-custom_tag.pom`
4. **Assert that first `version` of `dependency` is equal to `unspecified`**
5. Check out `issue/35_set_version_of_plugin_marker_dependency`
6. Run steps 2 and 3 again
7. **Assert that first `version` of `dependency` is equal to `custom_tag`**

#### Using LocalStack

I don't expect anyone to test this way, as it requires significant effort and time. But when working on this issue, I've set up a local instance of [LocalStack](https://www.localstack.cloud/) to mock S3 bucket. It worked the same way as with `mavenLocal`.

----

Also, before merging this PR we could maybe publish a new version (snapshot, RC) from this branch and test this plugin on real-life scenario. WDYT?

